### PR TITLE
Reliability Part 1

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -604,6 +604,7 @@ mod test {
     #[test]
     fn handle_logged_in_verify_connection_cookie() {
         let mut client_state = ClientState::new();
+        client_state.name = Some("Dr. Cookie Monster, Esquire".to_owned());
         assert_eq!(client_state.cookie, None);
         client_state.handle_logged_in("cookie monster".to_owned(), CLIENT_VERSION.to_owned());
         assert_eq!(client_state.cookie, Some("cookie monster".to_owned()));
@@ -883,6 +884,7 @@ mod test {
         let user_input = UserInput::Chat("memes".to_owned());
         let addr = fake_socket_addr();
 
+        client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
         client_state.handle_user_input_event(&udp_tx, &exit_tx, user_input, addr.clone());
         assert_eq!(client_state.sequence, 1);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -168,7 +168,7 @@ impl ClientState {
                 self.network.statistics.inc_tx_keep_alive_failed();
             } else {
                 self.network.statistics.inc_tx_keep_alive_success();
-                println!("Send KeepAlive yay!")
+                info!("Send KeepAlive yay!")
             }
         }
 
@@ -243,6 +243,7 @@ impl ClientState {
                         println!("Left room {}.", self.room.clone().unwrap());
                     }
                     self.room = None;
+                    self.chat_msg_seq_num = 0;
                 }
                 _ => {
                     //XXX more cases in which server replies OK

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,12 +95,16 @@ impl ClientState {
     fn handle_response_event(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>, addr: SocketAddr, opt_packet: Option<Packet>) {
         // All `None` packets should get filtered out up the hierarchy
         let packet = opt_packet.unwrap();
-        println!("DEBUG: Got packet from server {:?}: {:?}", addr, packet);
         match packet {
-            Packet::Response{sequence: _, request_ack: _, code} => {
+            Packet::Response{sequence, request_ack, code} => {
                 // XXX sequence
                 // XXX request_ack
-                match code {
+
+                if code.clone() != ResponseCode::KeepAlive {
+                    println!("DEBUG: Got packet from server {:?}: {:?} {:?} {:?}", addr, sequence, request_ack, code);
+                }
+
+                match code.clone() {
                     ResponseCode::OK => {
                         match self.handle_response_ok() {
                             Ok(_) => {},

--- a/src/client.rs
+++ b/src/client.rs
@@ -172,7 +172,7 @@ impl ClientState {
             }
         }
 
-        self.tick += 1;
+        self.tick = 1usize.wrapping_add(self.tick);
     }
 
     fn handle_user_input_event(&mut self,

--- a/src/net.rs
+++ b/src/net.rs
@@ -33,6 +33,8 @@ use self::bincode::{serialize, deserialize, Infinite};
 use self::semver::{Version, SemVerError};
 
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const DEFAULT_HOST: &str = "0.0.0.0";
+pub const DEFAULT_PORT: u16 = 12345;
 
 //////////////// Error handling ////////////////
 #[derive(Debug)]
@@ -200,17 +202,12 @@ impl UdpCodec for LineCodec {
 #[allow(dead_code)]
 pub fn bind(handle: &Handle, opt_host: Option<&str>, opt_port: Option<u16>) -> Result<UdpSocket, NetError> {
 
-    let host = if let Some(host) = opt_host { host } else { HOST };
-    let port = if let Some(port) = opt_port { port } else { PORT };
+    let host = if let Some(host) = opt_host { host } else { DEFAULT_HOST };
+    let port = if let Some(port) = opt_port { port } else { DEFAULT_PORT };
     let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
     let sock = UdpSocket::bind(&addr, &handle).expect("failed to bind socket");
     Ok(sock)
 }
-
-//XXX other functions
-
-pub const HOST: &str = "0.0.0.0";
-pub const PORT: u16 = 12345;
 
 #[allow(dead_code)]
 pub fn get_version() -> result::Result<Version, SemVerError> {

--- a/src/net.rs
+++ b/src/net.rs
@@ -35,6 +35,7 @@ use self::semver::{Version, SemVerError};
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 pub const DEFAULT_PORT: u16 = 12345;
+pub const PACKET_HISTORY_SIZE: usize = 15;
 
 //////////////// Error handling ////////////////
 #[derive(Debug)]

--- a/src/net.rs
+++ b/src/net.rs
@@ -90,7 +90,7 @@ pub enum ResponseCode {
     NotConnected(Option<String>),    // no equivalent in HTTP due to handling at lower (TCP) level
     PleaseUpgrade(Option<String>),   // client should give upgrade msg to user, but continue as if OK
     KeepAlive,                       // Server's heart is beating
-    OldPacket,                       // Internally used to ignore a packet
+    OldPacket,                       // Internally used to ignore a packet, just for testing
 }
 
 // chat messages sent from server to all clients other than originating client
@@ -321,12 +321,6 @@ impl NetworkManager {
             if head_seq_num < sequence && head_seq_num+1 == sequence{
                 self.tx_packets.push_back(packet);
             }
-            // Assumption is that a previous packet with this SQN failed to send,
-            // and this `packet` is up-to-date
-            //else if newest_sequence == sequence {
-            //    self.tx_packets.pop_back();
-            //    self.tx_packets.push_back(packet);
-            //}
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -69,6 +69,7 @@ pub enum RequestAction {
     NewRoom(String),
     JoinRoom(String),
     LeaveRoom,
+    TestSequenceNumber(u64),
 }
 
 // server response codes -- mostly inspired by https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
@@ -87,6 +88,7 @@ pub enum ResponseCode {
     NotConnected(Option<String>),    // no equivalent in HTTP due to handling at lower (TCP) level
     PleaseUpgrade(Option<String>),   // client should give upgrade msg to user, but continue as if OK
     KeepAlive,                       // Server's heart is beating
+    OldPacket,                       // Internally used to ignore a packet
 }
 
 // chat messages sent from server to all clients other than originating client
@@ -181,7 +183,7 @@ impl UdpCodec for LineCodec {
         match deserialize(buf) {
             Ok(decoded) => Ok((*addr, Some(decoded))),
             Err(e) => {
-                let local: SocketAddr = format!("{}:{}", "127.0.0.1", PORT.to_string()).parse().unwrap();
+                let local: SocketAddr = format!("{}:{}", "127.0.0.1", DEFAULT_PORT.to_string()).parse().unwrap();
                 // We only want to warn when the incoming packet is external to the host system
                 if local != *addr {
                     println!("WARNING: error during packet deserialization: {:?}", e);

--- a/src/net.rs
+++ b/src/net.rs
@@ -26,6 +26,7 @@ use std::io;
 use std::net::{self, SocketAddr};
 use std::str;
 use std::result;
+use std::time;
 use std::collections::VecDeque;
 
 use self::tokio_core::net::{UdpSocket, UdpCodec};
@@ -36,7 +37,7 @@ use self::semver::{Version, SemVerError};
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 pub const DEFAULT_PORT: u16 = 12345;
-pub const TIMEOUT_IN_SECONDS:    u64   = 10;
+const TIMEOUT_IN_SECONDS:    u64   = 5;
 const PACKET_HISTORY_SIZE: usize = 15;
 
 //////////////// Error handling ////////////////
@@ -217,6 +218,13 @@ pub fn bind(handle: &Handle, opt_host: Option<&str>, opt_port: Option<u16>) -> R
 #[allow(dead_code)]
 pub fn get_version() -> result::Result<Version, SemVerError> {
     Version::parse(VERSION)
+}
+
+pub fn has_connection_timed_out(heartbeat: Option<time::Instant>) -> bool {
+    match heartbeat {
+        Some(heartbeat) =>  time::Instant::now() - heartbeat > time::Duration::from_secs(TIMEOUT_IN_SECONDS),
+        None => false
+    }
 }
 
 pub struct NetworkStatistics {

--- a/src/net.rs
+++ b/src/net.rs
@@ -272,6 +272,7 @@ impl NetworkManager {
         self.tx_packets.back()
     }
 
+    /// The TX Packet queue must only contain Request packets.
     fn newest_tx_packet_seq_num(&self) -> Option<u64> {
         let opt_newest_packet = self.head_of_tx_packet_queue();
 
@@ -305,6 +306,9 @@ impl NetworkManager {
         }
     }
 
+    /// As we buffer new packets, we'll want to throw away the older packets.
+    /// We must be careful to ensure that we do not throw away packets that have
+    /// not yet been acknowledged by the end-point.
     pub fn buffer_tx_packet(&mut self, packet: Packet) {
         if let Packet::Request{ sequence, response_ack: _, cookie: _, action: _ } = packet {
             let opt_head_seq_num : Option<u64> = self.newest_tx_packet_seq_num();

--- a/src/net.rs
+++ b/src/net.rs
@@ -36,6 +36,7 @@ use self::semver::{Version, SemVerError};
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 pub const DEFAULT_PORT: u16 = 12345;
+pub const TIMEOUT_IN_SECONDS:    u64   = 10;
 const PACKET_HISTORY_SIZE: usize = 15;
 
 //////////////// Error handling ////////////////

--- a/src/net.rs
+++ b/src/net.rs
@@ -84,6 +84,7 @@ pub enum ResponseCode {
     ServerError(Option<String>),     // 500
     NotConnected(Option<String>),    // no equivalent in HTTP due to handling at lower (TCP) level
     PleaseUpgrade(Option<String>),   // client should give upgrade msg to user, but continue as if OK
+    KeepAlive,                       // Server's heart is beating
 }
 
 // chat messages sent from server to all clients other than originating client

--- a/src/server.rs
+++ b/src/server.rs
@@ -167,7 +167,7 @@ struct Room {
 }
 
 struct ServerState {
-    tick:           u64,
+    tick:           usize,
     players:        HashMap<PlayerID, Player>,
     player_map:     HashMap<String, PlayerID>,      // map cookie to player ID
     rooms:          HashMap<RoomID, Room>,
@@ -458,7 +458,7 @@ impl ServerState {
         if !already_playing {
             return ResponseCode::BadRequest(Some("cannot leave game because in lobby".to_owned()));
         }
-        
+
         let player: &mut Player = self.players.get_mut(&player_id).unwrap();
         {
             let room_id = &player.game_info.as_ref().unwrap().room_id;  // unwrap ok because of test above
@@ -593,7 +593,7 @@ impl ServerState {
             }
             Packet::UpdateReply{cookie, last_chat_seq, last_game_update_seq: _, last_gen: _} => {
                 let opt_player_id = self.get_player_id_by_cookie(cookie.as_str());
-                
+
                 if opt_player_id.is_none() {
                     return Err(Box::new(io::Error::new(ErrorKind::PermissionDenied, "invalid cookie")));
                 }
@@ -713,8 +713,8 @@ impl ServerState {
         match player.get_confirmed_chat_seq_num() {
             Some(chat_msg_seq_num) => {
                 let opt_newest_msg = room.get_newest_msg();
-                if opt_newest_msg.is_none() { 
-                    return None; 
+                if opt_newest_msg.is_none() {
+                    return None;
                 }
 
                 let newest_msg = opt_newest_msg.unwrap();
@@ -899,7 +899,7 @@ fn main() {
 */
                         }
 
-                    server_state.tick += 1;
+                    server_state.tick  = 1usize.wrapping_add(server_state.tick);
                 }
             }
 
@@ -1003,7 +1003,7 @@ mod test {
             server.join_room(player_id, String::from(room_name));
         }
 
-        // A chatless player now has something to to say 
+        // A chatless player now has something to to say
         server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
             cookie: player_cookie.clone(),
             last_chat_seq: Some(1),

--- a/src/server.rs
+++ b/src/server.rs
@@ -538,7 +538,8 @@ impl ServerState {
             _pkt @ Packet::Response{..} | _pkt @ Packet::Update{..} => {
                 return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "invalid packet - server-only")));
             }
-            Packet::Request{sequence: _, response_ack: _, cookie, action} => {
+            Packet::Request{sequence: sequence, response_ack: _, cookie, action} => {
+
                 match action {
                     RequestAction::Connect{..} => (),
                     _ => {
@@ -570,6 +571,12 @@ impl ServerState {
                             return Err(Box::new(io::Error::new(ErrorKind::PermissionDenied, "invalid cookie")));
                         }
                     };
+
+                    let player: Player = self.get_player(player_id);
+                    if sequence <= (player.next_resp_seq - 1) {
+                        return Err(Box::new(io::Error::new(ErrorKind::AlreadyExists, "")));
+                    }
+
                     match action {
                         RequestAction::Connect{..} => unreachable!(),
                         _ => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -485,8 +485,8 @@ impl ServerState {
     }
 
     fn remove_player(&mut self, player_id: PlayerID, player_cookie: String) {
-        let _opt_v = self.player_map.remove(&player_cookie);
-        let _opt_v = self.players.remove(&player_id);
+        self.player_map.remove(&player_cookie);
+        self.players.remove(&player_id);
     }
 
     fn handle_disconnect(&mut self, player_id: PlayerID) -> ResponseCode {
@@ -579,7 +579,7 @@ impl ServerState {
             Packet::Request{sequence, response_ack, cookie, action} => {
 
                 if action.clone() != RequestAction::KeepAlive {
-                    println!("Packet_RX {:?}/{:?}: {:?} {:?} {:?}", addr, cookie, sequence, response_ack, action);
+                    println!("Packet_RX {:?}/{:?}: Sequence: {:?} Response_Ack: {:?} RequestAction: {:?}", addr, cookie, sequence, response_ack, action);
                 }
 
                 match action {
@@ -928,7 +928,7 @@ fn main() {
 
                             if let Some(response_packet) = opt_response_packet {
                                 let response = (addr.clone(), response_packet);
-                                (&tx).unbounded_send(response).unwrap();
+                                tx.unbounded_send(response).unwrap();
                             }
                         } else {
                             let err = decode_result.unwrap_err();

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,7 +40,7 @@ use std::io::{self, ErrorKind};
 use std::iter;
 use std::net::SocketAddr;
 use std::process::exit;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::collections::HashMap;
 use std::fmt;
 use std::time;
@@ -146,12 +146,6 @@ impl Player {
         return false;
     }
 
-    fn is_timed_out(&self) -> bool {
-        match self.heartbeat {
-            Some(heartbeat) =>  time::Instant::now() - heartbeat > time::Duration::from_secs(net::TIMEOUT_IN_SECONDS),
-            None => false
-        }
-    }
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -160,7 +154,7 @@ struct ServerChatMessage {
     player_id:   PlayerID,
     player_name: String,
     message:     String,
-    timestamp:   time::Instant,
+    timestamp:   Instant,
 }
 
 #[derive(Clone, PartialEq)]
@@ -851,7 +845,8 @@ impl ServerState {
         let mut timed_out_players: Vec<PlayerID> = vec![];
 
         for (p_id, p) in self.players.iter() {
-            if p.is_timed_out() {
+            if net::has_connection_timed_out(p.heartbeat) {
+                println!("Player({}) has timed out", p.cookie);
                 timed_out_players.push(*p_id);
             }
         }


### PR DESCRIPTION
This is getting kind of long and I wanted keep my PR's short.

* Adds `/disconnect` support
  * Broadcast disconnect to other players if in a room
* Adds KeepAlive/HeartBeat support
  * Removes player from server data structures after 10s timeout
* *[sneak-peek]* Added NetworkManager to buffer packets
  * Only client-transmitted packets are buffered right now. 
* *[sneak-peek]* Added NetworkStatistics
  * Keep track of transmitted and received packet counts (for now at least)
* Unit tests for the above
* Minor clean up

Once this is reviewed, I'll proceed with the tracking/resubmitting side of things. I didn't know at the time that there was a bit of foundation needed.

There's also some test framework I was using via `TestSequenceNumber`. You can ignore this as it's only for my own testing and will be removed in the future. 