### PR TITLE
Reliability part2

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -306,29 +306,24 @@ impl ClientState {
     }
 
     fn handle_incoming_chats(&mut self, chats: Option<Vec<BroadcastChatMessage>> ) {
-        match chats {
-            Some(mut chat_messages) => {
-                chat_messages.retain(|ref chat_message| {
-                    self.chat_msg_seq_num < chat_message.chat_seq.unwrap()
-                });
-                // This loop does two things: 1) update chat_msg_seq_num, and
-                // 2) prints messages from other players
-                for chat_message in chat_messages {
-                    let chat_seq = chat_message.chat_seq.unwrap();
-                    self.chat_msg_seq_num = std::cmp::max(chat_seq, self.chat_msg_seq_num);
+        if let Some(mut chat_messages) = chats {
+            chat_messages.retain(|ref chat_message| {
+                self.chat_msg_seq_num < chat_message.chat_seq.unwrap()
+            });
+            // This loop does two things: 1) update chat_msg_seq_num, and
+            // 2) prints messages from other players
+            for chat_message in chat_messages {
+                let chat_seq = chat_message.chat_seq.unwrap();
+                self.chat_msg_seq_num = std::cmp::max(chat_seq, self.chat_msg_seq_num);
 
-                    match self.name.as_ref() {
-                        Some(ref client_name) => {
-                            if *client_name != &chat_message.player_name {
-                                println!("{}: {}", chat_message.player_name, chat_message.message);
-                            }
-                        }
-                        None => { panic!("Client name not set!"); }
+                if let Some(ref client_name) = self.name.as_ref() {
+                    if *client_name != &chat_message.player_name {
+                        println!("{}: {}", chat_message.player_name, chat_message.message);
                     }
-
+                } else {
+                   panic!("Client name not set!");
                 }
             }
-            None => {}
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -84,6 +84,7 @@ impl ClientState {
         self.last_req_action = None;
         self.chat_msg_seq_num = 0;
         self.room = None;
+        self.network.reinitialize();
     }
 
     fn in_game(&self) -> bool {

--- a/src/client.rs
+++ b/src/client.rs
@@ -644,11 +644,8 @@ mod test {
 
         let mut incoming_messages = vec![];
         for x in 0..10 {
-            incoming_messages.push( BroadcastChatMessage {
-                chat_seq: Some(x as u64),
-                player_name: "a player".to_owned(),
-                message: format!("message {}", x)
-            });
+            let new_msg =  BroadcastChatMessage::new(x as u64, "a player".to_owned(), format!("message {}", x));
+            incoming_messages.push(new_msg);
         }
 
         client_state.handle_incoming_chats(Some(incoming_messages));
@@ -660,12 +657,7 @@ mod test {
         let mut client_state = ClientState::new();
         client_state.chat_msg_seq_num = 10;
 
-        let incoming_messages = vec![
-            BroadcastChatMessage {
-                chat_seq: Some(10u64),
-                player_name: "a player".to_owned(),
-                message: format!("message {}", 10)
-            }];
+        let incoming_messages = vec![ BroadcastChatMessage::new(10u64, "a player".to_owned(), format!("message {}", 10))];
 
         client_state.handle_incoming_chats(Some(incoming_messages));
         assert_eq!(client_state.chat_msg_seq_num, 10);
@@ -677,12 +669,7 @@ mod test {
         let mut client_state = ClientState::new();
         client_state.chat_msg_seq_num = 10;
 
-        let incoming_messages = vec![
-            BroadcastChatMessage {
-                chat_seq: Some(11u64),
-                player_name: "a player".to_owned(),
-                message: format!("message {}", 11)
-            }];
+        let incoming_messages = vec![ BroadcastChatMessage::new(11u64, "a player".to_owned(), format!("message {}", 11))];
 
         client_state.handle_incoming_chats(Some(incoming_messages));
     }
@@ -696,11 +683,8 @@ mod test {
 
         let mut incoming_messages = vec![];
         for x in 0..20 {
-            incoming_messages.push( BroadcastChatMessage {
-                chat_seq: Some(x as u64),
-                player_name: "a player".to_owned(),
-                message: format!("message {}", x)
-            });
+            let new_msg =  BroadcastChatMessage::new(x as u64, "a player".to_owned(), format!("message {}", x));
+            incoming_messages.push(new_msg);
         }
 
         client_state.handle_incoming_chats(Some(incoming_messages));

--- a/src/net.rs
+++ b/src/net.rs
@@ -406,7 +406,11 @@ pub trait NetworkQueue<T: Ord+Sequenced> {
 
     /// Checks if the insertion of `sequence` induces a newly wrapped queue state.
     /// Sequence must be >=, or <, what we're comparing against. Cannot have wrapped yet.
-    fn is_seq_about_to_wrap(&self, buffer_wrap_index: Option<usize>, sequence: u64, oldest_seq_num: u64, newest_seq_num: u64) -> bool {
+    fn is_seq_about_to_wrap(&self,
+                            buffer_wrap_index: Option<usize>,
+                            sequence: u64,
+                            oldest_seq_num: u64,
+                            newest_seq_num: u64) -> bool {
         if buffer_wrap_index.is_none() {
             if sequence >= oldest_seq_num && sequence >= newest_seq_num {
                 self.is_seq_sufficiently_far_away(sequence, oldest_seq_num)
@@ -531,8 +535,9 @@ impl<T> NetworkQueue<T> for RXQueue<T>
     ///     [253, 254, 255, 1, 2, 3, 4]
     ///                     ^ wrapping index
     ///
-    /// Because we can receive `T`'s out-of-order even when wrapped, there are checks added below to safeguard against this.
-    /// Primarily, they cover the cases where out-of-order insertion would transition the queue into a wrapped state from a non-wrapped state.
+    /// Because we can receive `T`'s out-of-order even when wrapped, there are checks added below to safeguard
+    /// against this. Primarily, they cover the cases where out-of-order insertion would transition the queue into a
+    /// wrapped state from a non-wrapped state.
     fn buffer_item(&mut self, item: T) {
         let sequence = item.sequence_number();
 
@@ -627,7 +632,8 @@ impl<T> RXQueue<T> where T: Sequenced {
     /// Search within the RX queue, but we have no idea where to insert.
     /// This should cover only within the RX queue and not at the edges (front or back).
     /// We accomplish this by splitting the VecDequeue into a slice tuple and then binary searching on each slice.
-    /// Small note: The splitting of VecDequeue is into its 'front' and 'back' halves, based on how 'push_front' and 'push_back' were used.
+    /// Small note: The splitting of VecDequeue is into its 'front' and 'back' halves, based on how 'push_front'
+    /// and 'push_back' were used.
     fn find_rx_insertion_index(&self, item: &T) -> Option<usize> {
         let (front_slice, back_slice) = self.queue.as_slices();
         let f_result = front_slice.binary_search(&item);
@@ -691,7 +697,9 @@ pub struct NetworkManager {
     pub statistics:       NetworkStatistics,
     pub tx_packets:       TXQueue,                               // Back = Newest, Front = Oldest
     pub rx_packets:       RXQueue<Packet>,                       // Back = Newest, Front = Oldest
-    pub rx_chat_messages: Option<RXQueue<BroadcastChatMessage>>, // Back = Newest, Front = Oldest; Messages are drained into the Client; Server does not use this.
+    pub rx_chat_messages: Option<RXQueue<BroadcastChatMessage>>, // Back = Newest, Front = Oldest;
+                                                                 //     Messages are drained into the Client;
+                                                                 //     Server does not use this structure.
 }
 
 impl NetworkManager {
@@ -709,7 +717,10 @@ impl NetworkManager {
             statistics: self.statistics,
             tx_packets: self.tx_packets,
             rx_packets: self.rx_packets,
-            rx_chat_messages:  Some(RXQueue{ queue: RXQueue::<BroadcastChatMessage>::new(NETWORK_QUEUE_LENGTH), buffer_wrap_index: None }),
+            rx_chat_messages:  Some(RXQueue {
+                                        queue: RXQueue::<BroadcastChatMessage>::new(NETWORK_QUEUE_LENGTH),
+                                        buffer_wrap_index: None
+                                }),
         }
     }
 
@@ -1253,7 +1264,16 @@ mod test {
         let two = 2;
         let three = 3;
 
-        let input_order = [max_minus_4, two, max_minus_1, max_minus_5, u64_max, three, max_minus_2, zero, max_minus_3, one];
+        let input_order = [ max_minus_4,
+                            two,
+                            max_minus_1,
+                            max_minus_5,
+                            u64_max,
+                            three,
+                            max_minus_2,
+                            zero,
+                            max_minus_3,
+                            one ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
@@ -1267,7 +1287,10 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
+                .iter()
+                .cloned()); // Add in u64 max value plus others
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -1330,7 +1353,8 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -1364,7 +1388,8 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -1398,7 +1423,8 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -1433,7 +1459,8 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -1468,7 +1495,10 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
+                .iter()
+                .cloned());
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -1503,7 +1533,10 @@ mod test {
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
+                .iter()
+                .cloned()); // Add in u64 max value plus others
+
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());

--- a/src/net.rs
+++ b/src/net.rs
@@ -333,7 +333,7 @@ impl NetworkStatistics {
     }
 }
 
-/*
+
 pub trait Sequenced: Ord {
     fn sequence_number(&self) -> u64;
 }
@@ -349,7 +349,7 @@ impl Sequenced for BroadcastChatMessage {
         self.sequence_number()
     }
 }
-*/
+
 pub trait NetworkQueue<T: Ord+Sequenced> {
     fn new(size: usize) -> ItemQueue<T>
     {
@@ -492,7 +492,7 @@ impl NetworkQueue<Packet> for TXQueue {
 }
 
 impl<T> NetworkQueue<T> for RXQueue<T>
-        where T: Ord {
+        where T: Sequenced {
 
     fn as_queue_type(&self) -> &ItemQueue<T> {
         &self.queue
@@ -622,7 +622,7 @@ impl<T> NetworkQueue<T> for RXQueue<T>
     }
 }
 
-impl<T> RXQueue<T> where T: Ord {
+impl<T> RXQueue<T> where T: Sequenced {
 
     /// Search within the RX queue, but we have no idea where to insert.
     /// This should cover only within the RX queue and not at the edges (front or back).

--- a/src/net.rs
+++ b/src/net.rs
@@ -137,7 +137,7 @@ impl Ord for BroadcastChatMessage {
 }
 
 impl BroadcastChatMessage {
-    fn new(sequence: u64, name: String, msg: String) -> BroadcastChatMessage {
+    pub fn new(sequence: u64, name: String, msg: String) -> BroadcastChatMessage {
         BroadcastChatMessage {
             chat_seq: Some(sequence),
             player_name: name,

--- a/src/net.rs
+++ b/src/net.rs
@@ -555,12 +555,7 @@ impl<T> NetworkQueue<T> for RXQueue<T>
             if newest_seq_num == u64::max_value() {
                 if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
                     self.push_back(item);
-
-                    if let Some(buffer_wrap_index) = self.buffer_wrap_index {
-                        self.buffer_wrap_index = Some(buffer_wrap_index - 1);
-                    } else {
-                        self.buffer_wrap_index = Some(self.len() - 1);
-                    }
+                    self.buffer_wrap_index = Some(self.len() - 1);
                 } else {
                     self.push_front(item);
                 }
@@ -592,13 +587,14 @@ impl<T> NetworkQueue<T> for RXQueue<T>
                 self.insert_into_rx_queue(insertion_index, item);
             } else {
                 // Smallest sequence number (in value) that we have seen thus far.
+                panic!("Previously thought to be dead code. Prove us wrong!");
                 self.push_front(item);
 
                 if self.buffer_wrap_index.is_some() {
                     self.buffer_wrap_index = Some(self.buffer_wrap_index.unwrap() + 1);
                 }
             }
-        } else {
+        } else { // Sequence >= oldest_seq_num
             let insertion_index: Option<usize>;
             if sequence < newest_seq_num {
                 insertion_index = self.find_rx_insertion_index(&item);

--- a/src/net.rs
+++ b/src/net.rs
@@ -459,12 +459,12 @@ pub trait NetworkQueue<T: Sequenced> {
 type PacketQueue<T> = VecDeque<T>;
 
 pub struct TXQueue {
-    queue: PacketQueue<Packet>,
+    pub queue: PacketQueue<Packet>,
 }
 
 pub struct RXQueue<T> {
-    queue: PacketQueue<T>,
-    buffer_wrap_index: Option<usize>
+    pub queue: PacketQueue<T>,
+    pub buffer_wrap_index: Option<usize>
 }
 
 impl NetworkQueue<Packet> for TXQueue {
@@ -885,8 +885,8 @@ impl RXQueue<BroadcastChatMessage> {
 pub struct NetworkManager {
     pub statistics:     NetworkStatistics,
     pub tx_packets:       TXQueue,         // Back         = Newest, Front = Oldest
-    rx_packets:           RXQueue<Packet>,         // Back         = Newest, Front = Oldest
-    rx_chat_messages:     Option<RXQueue<BroadcastChatMessage>>, // Back = Newest, Front = Oldest; Messages are drained into the Client; Server does not use this.
+    pub rx_packets:           RXQueue<Packet>,         // Back         = Newest, Front = Oldest
+    pub rx_chat_messages:     Option<RXQueue<BroadcastChatMessage>>, // Back = Newest, Front = Oldest; Messages are drained into the Client; Server does not use this.
 }
 
 impl NetworkManager {

--- a/src/server.rs
+++ b/src/server.rs
@@ -955,7 +955,7 @@ fn main() {
 
                     server_state.remove_timed_out_clients();
 
-                    // Send a KeepAlive every scond
+                    // Send a KeepAlive every second
                     if (server_state.tick % 100) == 0 {
                         for player in server_state.players.values() {
                             let keep_alive = Packet::Response {

--- a/src/server.rs
+++ b/src/server.rs
@@ -795,11 +795,7 @@ impl ServerState {
         }
 
         let unsent_messages: Vec<BroadcastChatMessage> = raw_unsent_messages.iter().map(|msg| {
-            BroadcastChatMessage {
-                chat_seq:    Some(msg.seq_num),
-                player_name: msg.player_name.clone(),
-                message:     msg.message.clone()
-            }
+            BroadcastChatMessage::new(msg.seq_num, msg.player_name.clone(), msg.message.clone())
         }).collect();
 
         return Some(unsent_messages);


### PR DESCRIPTION
I like keeping these PR's small so here's another. This one is just to keep things structured nice, tidy, and reusable.

Part two primarily includes:
- Create types for netwayste packet buffering
  - `ItemQueue<T>` is a `VecDeque<T>`
- Traits~!
  - `NetworkQueue<T>` describes the basic functionality needed for a transmit or receive network queue
  - `TXQueue<T>` implements `NetworkQueue<T>` for transmission-related actions
   - `RXQueue<T>` implements `NetworkQueue<T>` for receiving-related actions
- RX queues can work for any type T, as long as T is bound to `Sequenced`. 
  - This means we now have `RXQueue<Packet>` and `RXQueue<BroadcastChatMessages>` and the handling of them uses the exact same infrastructure!! (Yay no code duplication which was where I was headed at first)
- `Sequenced` is a trait which adds ordering to custom types, by comparing internal sequence numbers
  - For packets, this is their packet sequence number
  - For Updates, this would be the chat messages' sequence number
  - This is the crux in which ordering is determined when searching through a buffer for the insertion index
- General refactoring to ensure the surrounding code/comments actually make sense
- Few more unit tests 
