### PR TITLE
Rename client to cli-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "server"
 path = "src/server.rs"
 
 [[bin]]
-name = "client"
+name = "cli-client"
 path = "src/client.rs"
 
 [dependencies]


### PR DESCRIPTION
This is to fix the bin conflict, so we can just go to the root repo and do one of these:
```
cargo run --bin client    # ggez gui
cargo run --bin server
cargo run --bin cli-client  # what was the netwayste client